### PR TITLE
ci(STUDOVRIGT-481): do not do anything in build.sh

### DIFF
--- a/.azure/azure-pipelines.npm.yml
+++ b/.azure/azure-pipelines.npm.yml
@@ -45,4 +45,3 @@ extends:
           dryRun: ${{ parameters.dryRun }}
           publishPublic: ${{ parameters.publishPublic }}
           publishInternal: ${{ parameters.publishInternal }}
-          testCommand: '--version' #kör 'npm --version' istället för 'npm run test'

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,1 @@
-npm install
-
-npm test
-
-rm -rf node_modules
+echo "Nothing to do here"


### PR DESCRIPTION
# Summary

build.sh is not needed anymore, but needs to be there for the pipeline to run. 